### PR TITLE
Add Linux controller discovery by connector label

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ You need to use a *USB 3.0 compatible* (SuperSpeed) Type C cable. USB 2.0-only c
 
 Note that the numbering of the i2c busses is not stable and the default bus `/dev/i2c-0` will be wrong randomly. To find the correct buse use `grep cd321x /sys/class/i2c-dev/i2c-?/device/?-0038/name`.
 
+Alternatively the `--connector` parameter will find a controller by matching its argument against the USB-C connector labels.
+Use `grep -a 'USB-C ' /sys/class/i2c-dev/i2c-?/device/*/of_node/connector/label` to list all USB-C connectors.
+
 Run it as root (`sudo ./tuxvdmtool`).
 
 ```
@@ -36,6 +39,7 @@ OPTIONS:
     -a, --address [<ADDRESS>...]    i2c target address of the USB-C controller device. [default:
                                     0x38]
     -b, --bus [<BUS>...]            i2c bus of the USB-C controller device. [default: /dev/i2c-0]
+    -c, --connector [<CONNECTOR>...]    (Partial) connector label of the USB-C controller device.
     -h, --help                    Print help information
     -V, --version                 Print version information
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,15 +5,20 @@
  */
 
 pub mod cd321x;
+#[cfg(target_os = "linux")]
+pub mod sysfs;
 
+#[cfg(target_os = "linux")]
+use crate::sysfs::get_i2c_dev_from_connector;
 use env_logger::Env;
-use log::error;
+use log::{error, info};
 use std::{fs, process::ExitCode};
 
 #[derive(Debug)]
 #[allow(dead_code)]
 enum Error {
     Device,
+    DeviceNotFound,
     Compatible,
     FeatureMissing,
     TypecController,
@@ -28,6 +33,11 @@ enum Error {
 
 type Result<T> = std::result::Result<T, Error>;
 
+#[cfg(not(target_os = "linux"))]
+fn get_i2c_dev_fromconnector(&connector: str) -> Result<(String, u16)> {
+    Err(Error::DeviceNotFound)
+}
+
 fn vdmtool() -> Result<()> {
     let matches = clap::command!()
         .arg(
@@ -38,6 +48,7 @@ fn vdmtool() -> Result<()> {
             clap::arg!(-a --address [ADDRESS] "i2c target address of the USB-C controller device.")
                 .default_value("0x38"),
         )
+        .arg(clap::arg!(-c --connector [CONNECTOR] "(Partial) connector label of the USB-C controller device."))
         .subcommand(
             clap::Command::new("reboot")
                 .about("reboot the target")
@@ -64,16 +75,28 @@ fn vdmtool() -> Result<()> {
         return Err(Error::Compatible);
     }
 
-    let addr_str = matches.get_one::<String>("address").unwrap();
     let addr: u16;
-    if let Some(stripped) = addr_str.strip_prefix("0x") {
-        addr = u16::from_str_radix(stripped, 16).map_err(Error::Parse)?;
-    } else {
-        addr = addr_str.parse::<u16>().map_err(Error::Parse)?;
+    let bus: String;
+
+    match matches.get_one::<String>("connector") {
+        Some(connector) => {
+            let connector = connector.to_ascii_lowercase();
+            (bus, addr) = get_i2c_dev_from_connector(&connector)?
+        }
+        None => {
+            let addr_str = matches.get_one::<String>("address").unwrap();
+            if let Some(stripped) = addr_str.strip_prefix("0x") {
+                addr = u16::from_str_radix(stripped, 16).map_err(Error::Parse)?;
+            } else {
+                addr = addr_str.parse::<u16>().map_err(Error::Parse)?;
+            }
+            bus = matches.get_one::<String>("bus").unwrap().to_string();
+        }
     }
+    info!("Using I2C bus:{bus} address:{addr:#x}");
 
     let code = device.to_uppercase();
-    let mut device = cd321x::Device::new(matches.get_one::<String>("bus").unwrap(), addr, code)?;
+    let mut device = cd321x::Device::new(&bus, addr, code)?;
 
     match matches.subcommand() {
         Some(("dfu", _)) => {

--- a/src/sysfs.rs
+++ b/src/sysfs.rs
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Copyright The Asahi Linux Contributors
+ */
+
+use log::debug;
+use std::fs;
+use std::path::Path;
+
+use crate::{Error, Result};
+
+pub(crate) fn get_i2c_dev_from_connector(connector: &str) -> Result<(String, u16)> {
+    let mut match_len = usize::MAX;
+    let mut candidate: Option<(String, u16)> = None;
+
+    // iterate over all i2c devices
+    for entry in fs::read_dir("/sys/class/i2c-dev/").map_err(Error::Io)? {
+        let path = entry.map_err(Error::Io)?.path();
+        if let Some(bus) = path.file_name() {
+            // look only into /sys/class/i2c-dev/i2c-[0-9]
+            if let Some(bus_id) = bus.to_str().unwrap().strip_prefix("i2c-") {
+                let path = path.join("device");
+                // find i2c devices with a matching connector label
+                if let Some((addr, label_len)) = discover_match(connector, &path, bus_id) {
+                    // Use the device with the shortest match so that cases like
+                    // "USB-C Back Left" and "USB-C Back Left Middle" can be matched
+                    // consistently. "back left" will always match the former.
+                    if label_len < match_len {
+                        let dev_path = Path::new("/dev").join(bus);
+                        match_len = label_len;
+                        candidate = Some((dev_path.to_string_lossy().to_string(), addr))
+                    }
+                }
+            }
+        }
+    }
+
+    candidate.ok_or(Error::DeviceNotFound)
+}
+
+fn discover_match(connector: &str, dev_path: &Path, bus_id: &str) -> Option<(u16, usize)> {
+    for entry in fs::read_dir(dev_path).ok()? {
+        let path = entry.ok()?.path();
+        if let Some((bus, addr)) = path.file_name()?.to_str()?.split_once("-") {
+            // Only consider I2C devices with the pattern  ("%d-%04x", bus, addr)
+            if bus != bus_id {
+                continue;
+            };
+            let label_path = path.join("of_node/connector/label");
+            let data = fs::read(label_path).ok()?;
+            // convert to lower case for case insensitive match
+            let label = std::str::from_utf8(&data).ok()?.to_ascii_lowercase();
+            if label.starts_with("usb-c ") && label.contains(connector) {
+                let addr = u16::from_str_radix(addr, 16).unwrap();
+                debug!("Found connector with label '{label}' for {bus}:{addr:#x}");
+                return Some((addr, label.len()));
+            }
+        }
+    }
+    None
+}


### PR DESCRIPTION
Linux I2C bus numbers are unfortunately not stable so one would have to check for the correct bus on each boot. Instead add code to find the correct I2C bus and device address based one the devicetree connector labels. This allows `tuxvdmtool --port "back right" ...` to work independently of the I2C bus numbering.
On some devices connector labels are prefixes of other labels. For consistency return the match with the shortest label. This means "back left" will always match "USB-C Back Left". To match "USB-C Back Left Middle" parts of its unique suffix are required in the query string, i.e. "back left m".
Following command can be used to list the labels of all USB-C connectors present on the system:
```
grep -a 'USB-C ' /sys/class/i2c-dev/i2c-?/device/*/of_node/connector/label
```